### PR TITLE
Add testing ruby versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ install:
 rvm:
   - ruby-head
   - 2.2.0-preview1
-  - 2.1.1
+  - 2.1.3
   - 2.0.0
   - rbx-2
 script:


### PR DESCRIPTION
- Test with 2.1.3, 2.2.0, head
- When 2.2.0 and head are failed, travis build is green . Because there are unstable
  - example https://travis-ci.org/sue445/rubicure/builds/35795859
