### PR TITLE
Better resetting

### DIFF
--- a/lib/crispy/crispy_internal/class_spy.rb
+++ b/lib/crispy/crispy_internal/class_spy.rb
@@ -70,6 +70,10 @@ module Crispy
         @registry[of_class] = spy
       end
 
+      def self.reset_all
+        @registry.each_value {|spy| spy.reinitialize }
+      end
+
     end
   end
 end

--- a/lib/crispy/crispy_internal/spy_base.rb
+++ b/lib/crispy/crispy_internal/spy_base.rb
@@ -21,14 +21,7 @@ module Crispy
 
       def self.new target, stubs_map = {}
         spy = self.of_target(target)
-        if spy
-          spy.restart
-          spy.erase_log
-          spy.reinitialize_stubber stubs_map
-          spy
-        else
-          super
-        end
+        spy ? spy.reinitialize(stubs_map) : super
       end
 
       def self.of_target target
@@ -49,6 +42,13 @@ module Crispy
 
       def append_received_message receiver, method_name, *arguments, &attached_block
         raise NotImplementedError
+      end
+
+      def reinitialize stubs_map = {}
+        restart
+        erase_log
+        reinitialize_stubber stubs_map
+        self
       end
 
       def stop

--- a/lib/crispy/crispy_world.rb
+++ b/lib/crispy/crispy_world.rb
@@ -6,6 +6,8 @@ module Crispy
 
       def reset
         ::Crispy::CrispyInternal::ConstChanger.recover_all
+        ::Crispy::CrispyInternal::Spy.reset_all
+        ::Crispy::CrispyInternal::ClassSpy.reset_all
       end
 
     end

--- a/test/test_crispy.rb
+++ b/test/test_crispy.rb
@@ -226,6 +226,14 @@ class TestCrispy < MiniTest::Test
       assert_equal 'xxx'             , ObjectClass.stubbed_method3
     end
 
+    def test_spy_forgets_all_after_resetting
+      CrispyWorld.reset
+
+      assert_equal 'before stubbed 1', ObjectClass.stubbed_method1
+      assert_equal 'before stubbed 2', ObjectClass.stubbed_method2
+      assert_empty @subject.received_messages
+    end
+
   end
 
   class TestCrispySpyIntoInstances < TestCrispy
@@ -272,6 +280,19 @@ class TestCrispy < MiniTest::Test
           assert_equal 'xx'                               , object.method_to_stub2
           assert_equal 'xxx'                              , object.method_to_stub3
         end
+      end
+
+      def test_spy_forgets_all_after_resetting
+        ::Crispy::CrispyWorld.reset
+
+        @object_instances.each do|object|
+          assert_equal 'method to stub 1 (before stubbed)', object.method_to_stub1
+          assert_equal 'method to stub 2 (before stubbed)', object.method_to_stub2
+          assert_equal 'method to stub 3 (before stubbed)', object.method_to_stub3
+        end
+
+        assert_empty @subject.received_messages
+        assert_empty @subject.received_messages_with_receiver
       end
 
     end

--- a/test/test_crispy.rb
+++ b/test/test_crispy.rb
@@ -226,11 +226,14 @@ class TestCrispy < MiniTest::Test
       assert_equal 'xxx'             , ObjectClass.stubbed_method3
     end
 
-    def test_spy_forgets_all_after_resetting
+    def test_spy_resets_stubbed_methods_after_resetting
       CrispyWorld.reset
-
       assert_equal 'before stubbed 1', ObjectClass.stubbed_method1
       assert_equal 'before stubbed 2', ObjectClass.stubbed_method2
+    end
+
+    def test_spy_forgets_received_messages_after_resetting
+      CrispyWorld.reset
       assert_empty @subject.received_messages
     end
 
@@ -282,7 +285,7 @@ class TestCrispy < MiniTest::Test
         end
       end
 
-      def test_spy_forgets_all_after_resetting
+      def test_spy_resets_stubbed_methods_after_resetting
         ::Crispy::CrispyWorld.reset
 
         @object_instances.each do|object|
@@ -290,7 +293,10 @@ class TestCrispy < MiniTest::Test
           assert_equal 'method to stub 2 (before stubbed)', object.method_to_stub2
           assert_equal 'method to stub 3 (before stubbed)', object.method_to_stub3
         end
+      end
 
+      def test_spy_forgets_received_messages_after_resetting
+        ::Crispy::CrispyWorld.reset
         assert_empty @subject.received_messages
         assert_empty @subject.received_messages_with_receiver
       end


### PR DESCRIPTION
Enhancement: Forget every spy log and reset stubbed methods by resetting.

This solves a possible problem when spying / stubbing an object used in many tests:
With the existing resetting method (reset only when reinitializing),
if the object is spied / stubbed in some tests but not in another,
the object is unintentionally left spied / stubbed in other tests.
So I decided to reinitializing every time CrispyWorld.reset_all.

In addressing the problem, I took care of not to hold extra spies after the target object is GCed with WeakRef.