### PR TITLE
add predicate method to check if the given class's instances are spied

### DIFF
--- a/lib/crispy.rb
+++ b/lib/crispy.rb
@@ -39,4 +39,8 @@ module Crispy
     defined? object.__CRISPY_SPY__
   end
 
+  def spied_instances? klass
+    !!::Crispy::CrispyInternal::ClassSpy.of_target(klass)
+  end
+
 end

--- a/test/test_crispy.rb
+++ b/test/test_crispy.rb
@@ -92,6 +92,20 @@ class TestCrispy < MiniTest::Test
 
   end
 
+  class TestCrispySpiedInstances < TestCrispy
+
+    def test_spied_instances_class_is_spied_instances
+      klass = Class.new
+      spy_into_instances klass
+      assert spied_instances?(klass)
+    end
+
+    def test_non_spied_instances_class_is_not_spied_instances
+      assert not(spied_instances?(Class.new))
+    end
+
+  end
+
   class TestCrispyStubConst < TestCrispy
 
     def setup


### PR DESCRIPTION
This feature is needed to implement `expect_any_instance_of` method in https://github.com/igrep/rspec-crispy .
`expect_any_instance_of` should raise an error when the given class's instances are not spied.
So it needs the predicate method.