### PR TITLE
specify minimum rubydoctest version

### DIFF
--- a/crispy.gemspec
+++ b/crispy.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "minitest", "~> 5"
-  spec.add_development_dependency "rubydoctest"
+  spec.add_development_dependency "rubydoctest", ">= 1.1.5"
 
   spec.required_ruby_version = '>= 2.0'
 end


### PR DESCRIPTION
I've forgotten to change it.
rubydoctest older than 1.1.5 doesn't work with Ruby 2.2. so it should be.