### PR TITLE
Spy blacklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,25 @@ Specify the **fully qualified name of the constant** instead of the constant its
 => "more cool value!"
 ```
 
+### Configure Methods which Spy Should NOT Log
+
+Sometimes, you may want to make a spy ignore some methods.
+
+```ruby
+>> x = YourCoolClass.new
+>> spy_into x, except: [:method_to_ignore1, :method_to_ignore2]
+>> x.method_to_ignore1
+>> x.method_to_ignore2
+>> x.your_cool_method
+
+>> spy(x).received? :method_to_ignore1
+=> false
+>> spy(x).received? :method_to_ignore2
+=> false
+>> spy(x).received? :your_cool_method
+=> true
+```
+
 ### Embedding Crispy into your Testing Framework
 
 Remember to reset all the changes made by Crispy, call `CrispyWorld.reset`.

--- a/lib/crispy.rb
+++ b/lib/crispy.rb
@@ -9,8 +9,8 @@ module Crispy
   module_function
 
   # Returns a Spy object to wrap all methods of the object.
-  def spy_into object, stubs_map = {}
-    ::Crispy::CrispyInternal::Spy.new object, stubs_map
+  def spy_into object, except: []
+    ::Crispy::CrispyInternal::Spy.new object, except: except
   end
 
   def double name_or_stubs_map = nil, stubs_map = {}
@@ -18,8 +18,8 @@ module Crispy
   end
 
   # Make and returns a Crispy::ClassSpy's instance to spy all instances of a class.
-  def spy_into_instances klass, stubs_map = {}
-    ::Crispy::CrispyInternal::ClassSpy.new klass, stubs_map
+  def spy_into_instances klass, except: []
+    ::Crispy::CrispyInternal::ClassSpy.new klass, except: except
   end
 
   def spy object

--- a/lib/crispy/crispy_internal/class_spy.rb
+++ b/lib/crispy/crispy_internal/class_spy.rb
@@ -7,7 +7,7 @@ module Crispy
 
       @registry = {}
 
-      def initialize klass, stubs_map = {}
+      def initialize klass, except: []
         @received_messages_with_receiver = []
 
         super

--- a/lib/crispy/crispy_internal/double.rb
+++ b/lib/crispy/crispy_internal/double.rb
@@ -2,13 +2,15 @@ module Crispy
   module CrispyInternal
     class Double
 
+      SPY_METHODS = %i[received_messages stub] + SpyBase::COMMON_RECEIVED_MESSAGE_METHODS_DEFINITION.keys
+
       def initialize name_or_stubs_map = nil, stubs_map = {}
         if name_or_stubs_map.is_a? ::Hash
           @name = ''.freeze
-          @spy = ::Crispy.spy_into(self).stub(name_or_stubs_map)
+          spy_into_self_as_double(name_or_stubs_map)
         else
           @name = name_or_stubs_map
-          @spy = ::Crispy.spy_into(self).stub(stubs_map)
+          spy_into_self_as_double(stubs_map)
         end
       end
 
@@ -27,6 +29,11 @@ module Crispy
           end
         END
       end
+
+      def spy_into_self_as_double stubs_map
+        @spy = ::Crispy.spy_into(self, except: SPY_METHODS).stub(stubs_map)
+      end
+      private :spy_into_self_as_double
 
     end
   end

--- a/lib/crispy/crispy_internal/double.rb
+++ b/lib/crispy/crispy_internal/double.rb
@@ -5,10 +5,10 @@ module Crispy
       def initialize name_or_stubs_map = nil, stubs_map = {}
         if name_or_stubs_map.is_a? ::Hash
           @name = ''.freeze
-          @spy = ::Crispy.spy_into(self, name_or_stubs_map)
+          @spy = ::Crispy.spy_into(self).stub(name_or_stubs_map)
         else
           @name = name_or_stubs_map
-          @spy = ::Crispy.spy_into(self, stubs_map)
+          @spy = ::Crispy.spy_into(self).stub(stubs_map)
         end
       end
 

--- a/lib/crispy/crispy_internal/spy.rb
+++ b/lib/crispy/crispy_internal/spy.rb
@@ -11,7 +11,7 @@ module Crispy
 
       attr_reader :received_messages
 
-      def initialize target, stubs_map = {}
+      def initialize target, except: []
         spy = self
         module_eval do
           define_method(:__CRISPY_SPY__) { spy }

--- a/lib/crispy/crispy_internal/spy_base.rb
+++ b/lib/crispy/crispy_internal/spy_base.rb
@@ -11,7 +11,7 @@ module Crispy
       ]
 
       def initialize target, except: []
-        @exceptions = except
+        @exceptions = except.map(&:to_sym)
 
         prepend_features target_to_class(target)
 
@@ -46,6 +46,7 @@ module Crispy
       end
 
       def reinitialize except: []
+        @exceptions.replace except.map(&:to_sym)
         restart
         erase_log
         reinitialize_stubber

--- a/lib/crispy/crispy_internal/spy_base.rb
+++ b/lib/crispy/crispy_internal/spy_base.rb
@@ -151,9 +151,11 @@ module Crispy
             define_wrapper(method_name)
           end
           klass.protected_instance_methods.each do|method_name|
+            next if @exceptions.include?(method_name)
             protected define_wrapper(method_name)
           end
           klass.private_instance_methods.each do|method_name|
+            next if @exceptions.include?(method_name)
             private define_wrapper(method_name)
           end
         end

--- a/lib/crispy/crispy_internal/spy_base.rb
+++ b/lib/crispy/crispy_internal/spy_base.rb
@@ -11,7 +11,7 @@ module Crispy
       ]
 
       def initialize target, except: []
-        @exceptions = except.map(&:to_sym)
+        @exceptions = Array(except).map(&:to_sym)
 
         prepend_features target_to_class(target)
 
@@ -46,7 +46,7 @@ module Crispy
       end
 
       def reinitialize except: []
-        @exceptions.replace except.map(&:to_sym)
+        @exceptions.replace Array(except).map(&:to_sym)
         restart
         erase_log
         reinitialize_stubber

--- a/lib/crispy/crispy_internal/spy_base.rb
+++ b/lib/crispy/crispy_internal/spy_base.rb
@@ -155,16 +155,13 @@ module Crispy
 
         self.module_eval do
           klass.public_instance_methods.each do|method_name|
-            next if method_name == :__CRISPY_SPY__ || @exceptions.include?(method_name)
-            define_wrapper(method_name)
+            define_wrapper(method_name) if method_name != :__CRISPY_SPY__ && !(@exceptions.include?(method_name))
           end
           klass.protected_instance_methods.each do|method_name|
-            next if @exceptions.include?(method_name)
-            protected define_wrapper(method_name)
+            protected define_wrapper(method_name) unless @exceptions.include?(method_name)
           end
           klass.private_instance_methods.each do|method_name|
-            next if @exceptions.include?(method_name)
-            private define_wrapper(method_name)
+            private define_wrapper(method_name) unless @exceptions.include?(method_name)
           end
         end
       end
@@ -173,16 +170,13 @@ module Crispy
       def redefine_wrappers klass, method_names
         self.module_eval do
           klass.public_instance_methods.each do|method_name|
-            next if method_name == :__CRISPY_SPY__ || !(method_names.include?(method_name))
-            define_wrapper(method_name)
+            define_wrapper(method_name) if method_name != :__CRISPY_SPY__ && method_names.include?(method_name)
           end
           klass.protected_instance_methods.each do|method_name|
-            next unless method_names.include?(method_name)
-            protected define_wrapper(method_name)
+            protected define_wrapper(method_name) if method_names.include?(method_name)
           end
           klass.private_instance_methods.each do|method_name|
-            next unless method_names.include?(method_name)
-            private define_wrapper(method_name)
+            private define_wrapper(method_name) if method_names.include?(method_name)
           end
         end
       end

--- a/test/doctest-fixtures/your_cool_class.rb
+++ b/test/doctest-fixtures/your_cool_class.rb
@@ -10,6 +10,10 @@ class YourCoolClass
   end
   def your_finalizer *args
   end
+  def method_to_ignore1
+  end
+  def method_to_ignore2
+  end
 
   class Again < self
     def your_another_method *args

--- a/test/test_crispy.rb
+++ b/test/test_crispy.rb
@@ -633,7 +633,7 @@ class TestCrispy < MiniTest::Test
       assert_same @expected_baz, @actual_baz
     end
 
-    def test_double_can_be_spied
+    def test_double_is_spied
       assert spied? @double
 
       assert_same @double.received_messages, spy(@double).received_messages
@@ -657,6 +657,23 @@ class TestCrispy < MiniTest::Test
       assert not(@double.received?(:non_used_method))
       assert not(@double.received_once?(:non_used_method))
       assert_equal 0, @double.count_received(:non_used_method)
+    end
+
+    def test_double_doesnt_spy_spy_methods
+      @double.stub(a: 0)
+      @double.received? :hoge
+      @double.received_once? :hoge
+      @double.count_received :hoge
+
+      should_not_logged = %i[
+        received? received_once? count_received
+        stub received_messages
+      ]
+
+      assert_empty(
+        @double.received_messages.select {|received_messages| should_not_logged.include? received_messages.method_name }
+      )
+
     end
 
   end

--- a/test/test_crispy.rb
+++ b/test/test_crispy.rb
@@ -62,6 +62,11 @@ class TestCrispy < MiniTest::Test
       123
     end
 
+    def self.non_spied1
+    end
+    def self.non_spied2
+    end
+
     def self.stubbed_method1
       'before stubbed 1'
     end
@@ -212,11 +217,12 @@ class TestCrispy < MiniTest::Test
   class TestCrispySpyIntoClass < TestCrispy
 
     def setup
-      spy_into(ObjectClass).stub(stubbed_method1: 1, stubbed_method2: 2)
+      spy_into(ObjectClass, except: :non_spied1).stub(stubbed_method1: 1, stubbed_method2: 2)
 
       ObjectClass.hoge 1, 2, 3
       ObjectClass.foo
       ObjectClass.hoge 3, 4, 5
+      ObjectClass.non_spied1
 
       @subject = spy(ObjectClass)
     end
@@ -264,6 +270,10 @@ class TestCrispy < MiniTest::Test
 
     def test_spy_of_instances_raises_an_error_given_non_spied_instances_object
       assert_raises(::Crispy::CrispyError){ spy_of_instances(Class.new) }
+    end
+
+    def test_spy_ignores_exceptions
+      assert not(spy(ObjectClass).received? :non_spied1)
     end
 
   end

--- a/test/test_crispy.rb
+++ b/test/test_crispy.rb
@@ -132,9 +132,8 @@ class TestCrispy < MiniTest::Test
     def setup
       @object = ObjectClass.new
 
-      @returned_spy = spy_into(
-        @object, method_to_stub1: :stubbed1, method_to_stub2: :stubbed2
-      )
+      @returned_spy = spy_into(@object)
+      @returned_spy.stub(method_to_stub1: :stubbed1, method_to_stub2: :stubbed2)
 
       @object.hoge 1, 2, 3
       @object.foo
@@ -213,7 +212,7 @@ class TestCrispy < MiniTest::Test
   class TestCrispySpyIntoClass < TestCrispy
 
     def setup
-      spy_into ObjectClass, stubbed_method1: 1, stubbed_method2: 2
+      spy_into(ObjectClass).stub(stubbed_method1: 1, stubbed_method2: 2)
 
       ObjectClass.hoge 1, 2, 3
       ObjectClass.foo
@@ -238,7 +237,7 @@ class TestCrispy < MiniTest::Test
     end
 
     def test_spy_overrides_stubbed_methods
-      spy_into ObjectClass, stubbed_method2: 'xx', stubbed_method3: 'xxx'
+      spy_into(ObjectClass).stub(stubbed_method2: 'xx', stubbed_method3: 'xxx')
 
       assert_equal 'before stubbed 1', ObjectClass.stubbed_method1
       assert_equal 'xx'              , ObjectClass.stubbed_method2
@@ -276,9 +275,8 @@ class TestCrispy < MiniTest::Test
     end
 
     def setup
-      @returned_spy = spy_into_instances(
-        object_class, method_to_stub1: :stubbed_instance_method1, method_to_stub2: :stubbed_instance_method2
-      )
+      @returned_spy = spy_into_instances(object_class)
+      @returned_spy.stub(method_to_stub1: :stubbed_instance_method1, method_to_stub2: :stubbed_instance_method2)
 
       @subject = spy_of_instances(object_class)
       @object_instances = Array.new(3){ object_class.new }
@@ -306,7 +304,7 @@ class TestCrispy < MiniTest::Test
       end
 
       def test_spy_overrides_stubbed_methods
-        spy_into_instances object_class, method_to_stub2: 'xx', method_to_stub3: 'xxx'
+        spy_into_instances(object_class).stub(method_to_stub2: 'xx', method_to_stub3: 'xxx')
 
         @object_instances.each do|object|
           assert_equal 'method to stub 1 (before stubbed)', object.method_to_stub1

--- a/test/test_crispy.rb
+++ b/test/test_crispy.rb
@@ -276,6 +276,18 @@ class TestCrispy < MiniTest::Test
       assert not(spy(ObjectClass).received? :non_spied1)
     end
 
+    def test_spy_overwrites_exceptions_by_spy_into_again
+      assert not(spy(ObjectClass).received? :non_spied1)
+
+      spy_into(ObjectClass, except: :non_spied2)
+
+      ObjectClass.non_spied1
+      ObjectClass.non_spied2
+
+      assert spy(ObjectClass).received? :non_spied1
+      assert not(spy(ObjectClass).received? :non_spied2)
+    end
+
   end
 
   class TestCrispySpyIntoInstances < TestCrispy


### PR DESCRIPTION
Add feature to specify methods which spy doesn't log: `except` keyword argument of `Crispy.spy_into`

This patch contains a breaking change: the keyword arguments of `Crispy.spy_into` are no more interpreted as stubbed methods.

And fixes https://github.com/igrep/crispy/issues/30 by making `double` ignore spy methods such as `received?`.

Left TODOs:

- [x] Document